### PR TITLE
HOURLY is missing

### DIFF
--- a/Alexa.NET.Management/Api/UpdateFrequency.cs
+++ b/Alexa.NET.Management/Api/UpdateFrequency.cs
@@ -2,6 +2,7 @@
 {
     public enum UpdateFrequency
     {
+        HOURLY,
         DAILY,
         WEEKLY,
         MONTHLY


### PR DESCRIPTION
Update frequency of flash briefing skill should have HOURLY definition. 
https://developer.amazon.com/docs/smapi/skill-manifest.html#updateFrequency-enumeration
Maybe MONTHLY is not needed.