### PR TITLE
Flashbriefing feed "uri" is "url"

### DIFF
--- a/Alexa.NET.Management/Api/FlashBriefingFeed.cs
+++ b/Alexa.NET.Management/Api/FlashBriefingFeed.cs
@@ -26,7 +26,7 @@ namespace Alexa.NET.Management.Api
         [JsonProperty("contentType"), JsonConverter(typeof(StringEnumConverter))]
         public ContentFeedType ContentType { get; set; }
 
-        [JsonProperty("uri")]
+        [JsonProperty("url")]
         public string Uri { get; set; }
     }
 }


### PR DESCRIPTION
Unfortunately, feed uri is `url`...
https://developer.amazon.com/docs/smapi/skill-manifest.html#feeds