### PR TITLE
allowPurchases => allowsPurchases

### DIFF
--- a/Alexa.NET.Management/Manifest/PrivacyAndCompliance.cs
+++ b/Alexa.NET.Management/Manifest/PrivacyAndCompliance.cs
@@ -5,7 +5,7 @@ namespace Alexa.NET.Management.Manifest
 {
     public class PrivacyAndCompliance
     {
-        [JsonProperty("allowPurchases")]
+        [JsonProperty("allowsPurchases")]
         public bool AllowPurchases { get; set; } 
 
         [JsonProperty("usesPersonalInfo")]


### PR DESCRIPTION
difficult to find though.
https://developer.amazon.com/docs/smapi/skill-manifest.html#privacyandcompliance
I didn't change the property name `AllowPurchases` since I'm not confident that it may cause error at CI.