### PR TITLE
Change case of skill stage

### DIFF
--- a/Alexa.NET.Management/Api/SkillStage.cs
+++ b/Alexa.NET.Management/Api/SkillStage.cs
@@ -7,8 +7,8 @@ namespace Alexa.NET.Management.Api
     public enum SkillStage
     {
         [EnumMember(Value="development")]
-        DEVELOPMENT,
+        development,
         [EnumMember(Value="live")]
-        LIVE
+        live
     }
 }

--- a/Alexa.NET.Management/Internals/AccountLinkingApi.cs
+++ b/Alexa.NET.Management/Internals/AccountLinkingApi.cs
@@ -26,15 +26,13 @@ namespace Alexa.NET.Management.Internals
 
         public async Task<bool> Delete(string skillId)
         {
-            var response = await Client.Delete(skillId, SkillStage.DEVELOPMENT.ToString());
+            var response = await Client.Delete(skillId, SkillStage.development.ToString());
             return response.StatusCode == HttpStatusCode.NoContent;
         }
 
         public Task Update(string skillId, AccountLinkData accountLinkData)
         {
-            return Client.Update(skillId, SkillStage.DEVELOPMENT.ToString(), new AccountLinkUpdate { Data = accountLinkData });
+            return Client.Update(skillId, SkillStage.development.ToString(), new AccountLinkUpdate { Data = accountLinkData });
         }
-
-
     }
 }

--- a/Alexa.NET.Management/Internals/SkillEnablementApi.cs
+++ b/Alexa.NET.Management/Internals/SkillEnablementApi.cs
@@ -20,19 +20,19 @@ namespace Alexa.NET.Management.Internals
 
         public async Task<bool> Enable(string skillId)
         {
-            var response = await Client.Enable(skillId, SkillStage.DEVELOPMENT.ToString());
+            var response = await Client.Enable(skillId, SkillStage.development.ToString());
             return response.StatusCode == HttpStatusCode.NoContent;
         }
 
         public async Task<bool> CheckEnablement(string skillId)
         {
-            var response = await Client.Enable(skillId, SkillStage.DEVELOPMENT.ToString());
+            var response = await Client.Enable(skillId, SkillStage.development.ToString());
             return response.StatusCode == HttpStatusCode.NoContent;
         }
 
         public async Task<bool> Disable(string skillId)
         {
-            var response = await Client.Disable(skillId, SkillStage.DEVELOPMENT.ToString());
+            var response = await Client.Disable(skillId, SkillStage.development.ToString());
             return response.StatusCode == HttpStatusCode.NoContent;
         }
     }

--- a/Alexa.NET.Management/ManagementRefitSettings.cs
+++ b/Alexa.NET.Management/ManagementRefitSettings.cs
@@ -21,12 +21,12 @@ namespace Alexa.NET.Management
         {
             if (value is SkillStage stage)
             {
-                if (stage == SkillStage.DEVELOPMENT)
+                if (stage == SkillStage.development)
                 {
                     return "development";
                 }
 
-                if (stage == SkillStage.LIVE)
+                if (stage == SkillStage.live)
                 {
                     return "live";
                 }

--- a/Tests/Alexa.NET.Management.Tests/InSkillProductTests.cs
+++ b/Tests/Alexa.NET.Management.Tests/InSkillProductTests.cs
@@ -255,7 +255,7 @@ namespace Alexa.NET.Management.Tests
                 Assert.Equal("/v1/inSkillProducts/string/stages/development/summary", req.RequestUri.PathAndQuery);
             }, Utility.ExampleFileContent<ProductSummary>("ProductSummary.json")));
 
-            var response = await management.InSkillProducts.GetSummary("string", SkillStage.DEVELOPMENT);
+            var response = await management.InSkillProducts.GetSummary("string", SkillStage.development);
             Assert.NotNull(response);
         }
 

--- a/Tests/Alexa.NET.Management.Tests/IntentRequestHistoryTests.cs
+++ b/Tests/Alexa.NET.Management.Tests/IntentRequestHistoryTests.cs
@@ -39,13 +39,13 @@ namespace Alexa.NET.Management.Tests
         {
             var api = new ManagementApi("wibble", new ActionHandler(req =>
             {
-                Assert.Equal("/v1/skills/xxx/history/intentRequests?nextToken=yyy&stage=DEVELOPMENT&interactionType=ONE_SHOT", req.RequestUri.PathAndQuery);
+                Assert.Equal("/v1/skills/xxx/history/intentRequests?nextToken=yyy&stage=development&interactionType=ONE_SHOT", req.RequestUri.PathAndQuery);
             }, new IntentRequestHistoryResponse()));
 
             var request = new IntentRequestHistoryRequest
             {
                 NextToken = "yyy",
-                Stage = SkillStage.DEVELOPMENT,
+                Stage = SkillStage.development,
                 InteractionType = InteractionType.ONE_SHOT
             };
 

--- a/Tests/Alexa.NET.Management.Tests/PackageTests.cs
+++ b/Tests/Alexa.NET.Management.Tests/PackageTests.cs
@@ -169,7 +169,7 @@ namespace Alexa.NET.Management.Tests
                 message.Headers.Location = new Uri("/v1/skills/skillid/imports/importId", UriKind.Relative);
                 return Task.FromResult(message);
             }));
-            var response = await management.Package.CreateExportRequest("skillid", SkillStage.DEVELOPMENT);
+            var response = await management.Package.CreateExportRequest("skillid", SkillStage.development);
             Assert.NotNull(response);
             Assert.Equal("/v1/skills/skillid/imports/importId", response.ToString());
         }
@@ -178,7 +178,7 @@ namespace Alexa.NET.Management.Tests
         public async Task CreateExportRequestThrowsNullSkillId()
         {
             var management = new ManagementApi("xxx");
-            await Assert.ThrowsAsync<ArgumentNullException>(() => management.Package.CreateExportRequest(null, SkillStage.DEVELOPMENT));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => management.Package.CreateExportRequest(null, SkillStage.development));
         }
 
         [Fact]

--- a/Tests/Alexa.NET.Management.Tests/SkillListConversionTests.cs
+++ b/Tests/Alexa.NET.Management.Tests/SkillListConversionTests.cs
@@ -23,7 +23,7 @@ namespace Alexa.NET.Management.Tests
             var skill = response.Skills.First();
             Assert.Equal("amzn1.ask.skill.6acdbdf8-8420-440e-823e-aaaaaaaabbbb", skill.SkillId);
             Assert.Equal(PublicationStatus.PUBLISHED,skill.Status);
-            Assert.Equal(SkillStage.DEVELOPMENT,skill.Stage);
+            Assert.Equal(SkillStage.development,skill.Stage);
         }
     }
 }

--- a/Tests/Alexa.NET.Management.Tests/SkillValidationTests.cs
+++ b/Tests/Alexa.NET.Management.Tests/SkillValidationTests.cs
@@ -21,7 +21,7 @@ namespace Alexa.NET.Management.Tests
                 Assert.Equal(HttpMethod.Post,req.Method);
                 Assert.Equal("/v1/skills/skillid/stage/development/validations",req.RequestUri.PathAndQuery);
             },new SkillValidationResponse()));
-            var response = await management.SkillValidation.Submit("skillid", SkillStage.DEVELOPMENT);
+            var response = await management.SkillValidation.Submit("skillid", SkillStage.development);
             Assert.NotNull(response);
         }
 
@@ -37,7 +37,7 @@ namespace Alexa.NET.Management.Tests
                 Assert.Single(response.Locales);
                 Assert.Equal("en-GB", response.Locales.First());
             }, new SkillValidationResponse()));
-            var task = await management.SkillValidation.Submit("skillid", SkillStage.DEVELOPMENT, SupportedLocales.EnglishUnitedKingdom);
+            var task = await management.SkillValidation.Submit("skillid", SkillStage.development, SupportedLocales.EnglishUnitedKingdom);
             Assert.NotNull(task);
         }
 
@@ -57,7 +57,7 @@ namespace Alexa.NET.Management.Tests
                 Assert.Equal(HttpMethod.Post,req.Method);
                 Assert.Equal("/v1/skills/skillid/stage/development/validations", req.RequestUri.PathAndQuery);
             }, Utility.ExampleFileContent<SkillValidationResponse>("InProgressValidation.json")));
-            var task = await api.SkillValidation.Submit("skillid", SkillStage.DEVELOPMENT);
+            var task = await api.SkillValidation.Submit("skillid", SkillStage.development);
             Assert.Equal("33333333-3333-3333-3333-333333333333", task.Id);
             Assert.Equal(ValidationStatus.IN_PROGRESS,task.Status);
             Assert.Null(task.Result);
@@ -71,7 +71,7 @@ namespace Alexa.NET.Management.Tests
                 Assert.Equal(HttpMethod.Get,req.Method);
                 Assert.Equal("/v1/skills/skillid/stages/development/validations/validationid",req.RequestUri.PathAndQuery);
             },new SkillValidationResponse()));
-            var task = await api.SkillValidation.Get("skillid",SkillStage.DEVELOPMENT,"validationid");
+            var task = await api.SkillValidation.Get("skillid",SkillStage.development,"validationid");
             Assert.NotNull(task);
         }
 
@@ -83,7 +83,7 @@ namespace Alexa.NET.Management.Tests
                 Assert.Equal(HttpMethod.Get, req.Method);
                 Assert.Equal("/v1/skills/skillid/stages/development/validations/validationid", req.RequestUri.PathAndQuery);
             }, Utility.ExampleFileContent<SkillValidationResponse>("ValidationResult.json")));
-            var task = await api.SkillValidation.Get("skillid", SkillStage.DEVELOPMENT, "validationid");
+            var task = await api.SkillValidation.Get("skillid", SkillStage.development, "validationid");
             
             Assert.Equal("11111111-1111-1111-1111-111111111111",task.Id);
             Assert.Equal(ValidationStatus.SUCCESSFUL,task.Status);

--- a/Tests/Alexa.NET.Management.Tests/UtteranceProfilerTests.cs
+++ b/Tests/Alexa.NET.Management.Tests/UtteranceProfilerTests.cs
@@ -20,7 +20,7 @@ namespace Alexa.NET.Management.Tests
                 Assert.Equal(HttpMethod.Post, req.Method);
                 Assert.Equal("/v1/skills/skillId/stages/development/interactionModel/locales/en-GB/profileNlu", req.RequestUri.PathAndQuery);
             }, new UtteranceProfilerResponse()));
-            await management.UtteranceProfiler.Analyze("skillId", SkillStage.DEVELOPMENT, "en-GB", "test");
+            await management.UtteranceProfiler.Analyze("skillId", SkillStage.development, "en-GB", "test");
         }
 
         [Fact]
@@ -38,7 +38,7 @@ namespace Alexa.NET.Management.Tests
                     Content = new StringContent(JsonConvert.SerializeObject(new UtteranceProfilerResponse()))
                 };
             }));
-            await management.UtteranceProfiler.Analyze("skillId", SkillStage.DEVELOPMENT, "en-GB", "test", "test2");
+            await management.UtteranceProfiler.Analyze("skillId", SkillStage.development, "en-GB", "test", "test2");
         }
 
         [Fact]


### PR DESCRIPTION
Skill stage path parameter is case sensitive on Alexa and expects lowercase 'development'. The SkillStage enum was fully capitalized and calling ToString() on this enum was returning the fully capitalized value DEVELOPMENT, causing 404s on Account Linking methods