### PR TITLE
Change SUCCESSFUL to SUCCEDDED in SkillStatusState

### DIFF
--- a/Alexa.NET.Management/Skills/SkillStatusState.cs
+++ b/Alexa.NET.Management/Skills/SkillStatusState.cs
@@ -4,6 +4,6 @@
     {
         IN_PROGRESS,
         FAILED,
-        SUCCESSFUL
+        SUCCEEDED
     }
 }


### PR DESCRIPTION
Currently when calling this method, you get a serialization exception if the api returns successful because the string that is returned now is SUCCEEDED.