### PR TITLE
Update SharedSlotType.cs

### DIFF
--- a/Alexa.NET.Management/SlotType/SharedSlotType.cs
+++ b/Alexa.NET.Management/SlotType/SharedSlotType.cs
@@ -4,7 +4,7 @@ namespace Alexa.NET.Management.SlotType
 {
     public class SharedSlotType
     {
-        [JsonProperty("id")]
+        [JsonProperty("id", NullValueHandling = NullValueHandling.Ignore)]
         public string Id { get; set; }
 
         [JsonProperty("name")]

--- a/Alexa.NET.Management/SlotType/SharedSlotType.cs
+++ b/Alexa.NET.Management/SlotType/SharedSlotType.cs
@@ -4,6 +4,9 @@ namespace Alexa.NET.Management.SlotType
 {
     public class SharedSlotType
     {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
         [JsonProperty("name")]
         public string Name { get; set; }
 


### PR DESCRIPTION
Hello,

It should have `id`. It can be extracted from `_links` somehow, but it would be nice to have the property.

```
{
  "slotTypes": [
    {
      "_links": {
        "self": {
          "href": "/v1/skills/api/custom/interactionModel/slotTypes/amzn1.ask.interactionModel.slotType.cedb3d3f-4410-4dd5-b8b3-1aa1e67f4fc4"
        }
      },
      "id": "amzn1.ask.interactionModel.slotType.cedb3d3f-4410-4dd5-b8b3-1aa1e67f4fc4",
      "name": "myslot"
    }
  ]
}
```