### PR TITLE
Add missing json compare assertions

### DIFF
--- a/Tests/Alexa.NET.Management.Tests/SkillDevelopmentTests.cs
+++ b/Tests/Alexa.NET.Management.Tests/SkillDevelopmentTests.cs
@@ -170,9 +170,9 @@ namespace Alexa.NET.Management.Tests
 
             var subscriptionRequest = new Subscription
             {
-                Name = "my subscription request",
+                Name = "my subscription",
                 VendorId = "M123456EXAMPLE",
-                SubscriberId = "ABC",
+                SubscriberId = "ABCDEF",
                 Events = new[] {AlexaDevelopmentEventType.SkillPublish}
             };
 

--- a/Tests/Alexa.NET.Management.Tests/SkillDevelopmentTests.cs
+++ b/Tests/Alexa.NET.Management.Tests/SkillDevelopmentTests.cs
@@ -46,7 +46,7 @@ namespace Alexa.NET.Management.Tests
                 Assert.Equal("/v0/developmentEvents/subscribers", req.RequestUri.PathAndQuery);
                 var raw = await req.Content.ReadAsStringAsync();
                 var request = JsonConvert.DeserializeObject<Subscriber>(raw);
-                Utility.CompareJson(request, "CreateSubscriberRequest.json");
+                Assert.True(Utility.CompareJson(request, "CreateSubscriberRequest.json"));
 
                 var resp = new HttpResponseMessage(HttpStatusCode.Created);
                 resp.Headers.Location = new Uri(responseLocation, UriKind.Relative);
@@ -77,7 +77,7 @@ namespace Alexa.NET.Management.Tests
                 Assert.Equal(requestLocation, req.RequestUri.PathAndQuery);
                 var raw = await req.Content.ReadAsStringAsync();
                 var request = JsonConvert.DeserializeObject<SubscriberUpdate>(raw);
-                Utility.CompareJson(request, "CreateSubscriberRequest.json","vendorId");
+                Assert.True(Utility.CompareJson(request, "CreateSubscriberRequest.json","vendorId"));
             },HttpStatusCode.NoContent));
 
             var subscriptionRequest = new SubscriberUpdate
@@ -161,7 +161,7 @@ namespace Alexa.NET.Management.Tests
                 Assert.Equal("/v0/developmentEvents/subscriptions", req.RequestUri.PathAndQuery);
                 var raw = await req.Content.ReadAsStringAsync();
                 var request = JsonConvert.DeserializeObject<Subscription>(raw);
-                Utility.CompareJson(request, "CreateSubscriptionRequest.json");
+                Assert.True(Utility.CompareJson(request, "CreateSubscriptionRequest.json"));
 
                 var resp = new HttpResponseMessage(HttpStatusCode.Created);
                 resp.Headers.Location = new Uri(responseLocation, UriKind.Relative);


### PR DESCRIPTION
While getting to know the source I found a couple of places where assertions were missing from the `Utility.CompareJson ` invocations. Maybe the assert can be pulled into the utility if it's only used for testing?

This breaks one test that I fixed by changing the input data to match the expected. `CreateSubscriptionRequest.json` seems to be involved in other tests as well and changing it instead would break the other tests.