### PR TITLE
Add 'SKIPPED' resource status

### DIFF
--- a/Alexa.NET.Management/Package/ResourceStatus.cs
+++ b/Alexa.NET.Management/Package/ResourceStatus.cs
@@ -8,6 +8,7 @@ namespace Alexa.NET.Management.Package
     {
         FAILED,
         IN_PROGRESS,
+        SKIPPED,
         SUCCEEDED,
         ROLLBACK_IN_PROGRESS,
         ROLLBACK_SUCCEEDED,


### PR DESCRIPTION
The library is throwing exceptions when the ResourceStatus on a status for a skill package is "SKIPPED". 

Looks like the enum was missing the option. 

[This should catch it up to the documentation here. ](https://developer.amazon.com/en-US/docs/alexa/smapi/skill-package-api-reference.html#create-upload-url)